### PR TITLE
Options to : addAmpliRG.py and ampliVariantCalling.py 

### DIFF
--- a/bin/addAmpliRG.py
+++ b/bin/addAmpliRG.py
@@ -45,7 +45,7 @@ def getSourceRegion(read, regions, anchor_offset=0, whole_region=False):
                 break
             if ref_end <= curr_region.end + anchor_offset:
                 if ref_end >= curr_region.end - anchor_offset:
-                    if whole_amplicons :
+                    if whole_region :
                         if ref_start < (curr_region.start - anchor_offset):
                             continue
                         if ref_start <= (curr_region.start + anchor_offset):
@@ -62,7 +62,7 @@ def getSourceRegion(read, regions, anchor_offset=0, whole_region=False):
                 break
             if ref_start >= curr_region.start - anchor_offset:
                 if ref_start <= curr_region.start + anchor_offset:
-                    if whole_amplicons :
+                    if whole_region :
                         if ref_end > (curr_region.end + anchor_offset):
                             continue
                         if ref_end >= (curr_region.end - anchor_offset):


### PR DESCRIPTION
**In addAmpliRG.py** 
I added an option in case we have amplicons included on another.
Example :
> chr4	1806031	1806150	ampl1	0	+	1806053	1806128
> **chr4	1806081	1806239	ampl2	0	+	1806101	1806220**
> **chr4	1806095	1806236	ampl3	0	+	1806117	1806216**
> chr4	1806160	1806284	ampl4	0	+	1806181	1806262
IGV snapshot : 

- first track : addAmpliRG.py (without new option)
- second track : addAmpliRG.py (with new option)
- third track : raw bam


![igv_snapshot](https://user-images.githubusercontent.com/10559615/73662683-82b58c80-469c-11ea-9a1d-5ac60e43036d.png)

**In ampliVariantCalling.py**

Add option to choose cmd line to launch vardict.
